### PR TITLE
Added AccessManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 cover.out
 .goxc.json
+/.idea
+*.iml

--- a/gcm/mocks_server_gen_test.go
+++ b/gcm/mocks_server_gen_test.go
@@ -29,10 +29,11 @@ func (_m *MockPubSubSource) EXPECT() *_MockPubSubSourceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockPubSubSource) Subscribe(_param0 *server.Route) *server.Route {
+func (_m *MockPubSubSource) Subscribe(_param0 *server.Route) (*server.Route, error) {
 	ret := _m.ctrl.Call(_m, "Subscribe", _param0)
 	ret0, _ := ret[0].(*server.Route)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockPubSubSourceRecorder) Subscribe(arg0 interface{}) *gomock.Call {

--- a/guble/message.go
+++ b/guble/message.go
@@ -91,6 +91,7 @@ const (
 	SUCCESS_FETCH_END     = "fetch-end"
 	SUCCESS_SUBSCRIBED_TO = "subscribed-to"
 	SUCCESS_CANCELED      = "canceled"
+	ERROR_SUBSCRIBED_TO   = "error-subscribed-to"
 	ERROR_SEND            = "error-send"
 	ERROR_BAD_REQUEST     = "error-bad-request"
 	ERROR_INTERNAL_SERVER = "error-server-internal"

--- a/gubled/gubled.go
+++ b/gubled/gubled.go
@@ -123,7 +123,7 @@ func StartupService(args Args) *server.Service {
 		CreateMessageStoreBackend(args),
 		server.NewMessageEntry(router),
 		router,
-	)
+		server.NewRestAccessManager("http://localhost:9000/follow/accessAllowed"))
 
 	for _, module := range CreateModules(args) {
 		service.Register(module)

--- a/gubled/gubled.go
+++ b/gubled/gubled.go
@@ -123,7 +123,7 @@ func StartupService(args Args) *server.Service {
 		CreateMessageStoreBackend(args),
 		server.NewMessageEntry(router),
 		router,
-		server.NewRestAccessManager("http://localhost:9000/follow/accessAllowed"))
+		server.NewAllowAllAccessManager(true))
 
 	for _, module := range CreateModules(args) {
 		service.Register(module)

--- a/gubled/gubled.go
+++ b/gubled/gubled.go
@@ -116,7 +116,9 @@ func Main() {
 }
 
 func StartupService(args Args) *server.Service {
-	router := server.NewPubSubRouter().Go()
+	router := server.NewPubSubRouter()
+	router.SetAccessManager(server.NewAllowAllAccessManager(true))
+	router.Go()
 	service := server.NewService(
 		args.Listen,
 		CreateKVStoreBackend(args),

--- a/server/accessmanager.go
+++ b/server/accessmanager.go
@@ -10,7 +10,6 @@ import (
 type AllowAllAccessManager bool
 
 func NewAllowAllAccessManager(allowAll bool) AllowAllAccessManager {
-	fmt.Println("LOLZ")
 	return AllowAllAccessManager(allowAll)
 }
 
@@ -37,26 +36,20 @@ func (am RestAccessManager) AccessAllowed(accessType AccessType, userId string, 
 
 	resp, err := http.DefaultClient.Get(url)
 
-	defer resp.Body.Close()
-
 	if (err != nil) {
-
-		fmt.Println("FAILZ: %s", err)
+		guble.Warn("RestAccessManager: %v", err)
 		return false
 	}
-
+	defer resp.Body.Close()
 	responseBody, err := ioutil.ReadAll(resp.Body)
 
 	if (err != nil || resp.StatusCode != 200) {
-		fmt.Println("FAILZ: %s %s", string(responseBody), err)
+		fmt.Println("RestAccessManager: ", string(responseBody), err)
 		return false
 	}
 
-	if ("true" == string(responseBody)) {
-		return true
-	}
+	guble.Debug("RestAccessManager: %v, %v, %v, %v", accessType, userId, path, string(responseBody))
 
-
-	return false
+	return "true" == string(responseBody)
 
 }

--- a/server/accessmanager.go
+++ b/server/accessmanager.go
@@ -1,0 +1,54 @@
+package server
+import (
+	"github.com/smancke/guble/guble"
+	"fmt"
+	"net/http"
+	"io"
+	"bytes"
+)
+
+
+type AllowAllAccessManager bool
+
+func NewAllowAllAccessManager(allowAll bool) AllowAllAccessManager {
+	fmt.Println("LOLZ")
+	return AllowAllAccessManager(allowAll)
+}
+
+func (am AllowAllAccessManager) AccessAllowed(accessType AccessType, userId string, path guble.Path) bool {
+	return bool(am);
+}
+
+type RestAccessManager string
+
+func NewRestAccessManager(url string) RestAccessManager {
+	return RestAccessManager(url)
+}
+
+func (am RestAccessManager) AccessAllowed(accessType AccessType, userId string, path guble.Path) bool {
+	url := string(am)+"?type="
+	if (accessType == READ) {
+		url += "read"
+	} else {
+		url += "write"
+	}
+	url += "&user="+ userId
+	url += "&path="+string(path)
+	resp, err := http.DefaultClient.Get(url)
+	defer resp.Close()
+
+	if(err != nil) {
+		//TODO log error
+		return false
+	}
+
+	buff := make([]byte, 4, 4)
+	io.ReadFull(resp.Body, buff)
+	if("true" == string(buff)) {
+		return true
+	}
+
+
+	return false
+
+}

--- a/server/accessmanager.go
+++ b/server/accessmanager.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"io"
-	"bytes"
 )
 
 
@@ -35,7 +34,6 @@ func (am RestAccessManager) AccessAllowed(accessType AccessType, userId string, 
 	url += "&user="+ userId
 	url += "&path="+string(path)
 	resp, err := http.DefaultClient.Get(url)
-	defer resp.Close()
 
 	if(err != nil) {
 		//TODO log error

--- a/server/accessmanager_test.go
+++ b/server/accessmanager_test.go
@@ -1,10 +1,43 @@
 package server
 import (
 	"testing"
+	"github.com/smancke/guble/guble"
 	"github.com/stretchr/testify/assert"
+	"fmt"
 )
 
-func Test_AllowAllAccessManager (t *testing.T) {
+type TestAccessManager struct {
+	access map[string]map[guble.Path]bool
+}
+
+func NewTestAccessManager() *TestAccessManager {
+	return &TestAccessManager{
+		access:make(map[string]map[guble.Path]bool),
+	}
+}
+
+func (tam *TestAccessManager ) allow(userId string, path guble.Path) {
+	v, ok := tam.access[userId];
+	if(!ok) {
+		v = make(map[guble.Path]bool);
+		tam.access[userId] = v;
+	}
+	v[path] = true;
+}
+
+func (tam *TestAccessManager ) AccessAllowed(accessType AccessType, userId string, path guble.Path) bool {
+	fmt.Print("AccessAllowed: ", userId, path)
+	v, ok := tam.access[userId]
+	if(ok) {
+		_ , ok = v[path];
+		fmt.Println(" : true")
+		return ok
+	}
+	fmt.Println(" : false")
+	return false;
+}
+
+func Test_AllowAllAccessManager(t *testing.T) {
 	a := assert.New(t)
 	am := AccessManager(NewAllowAllAccessManager(true))
 	a.True(am.AccessAllowed(READ, "userid", "/path"))
@@ -16,7 +49,7 @@ func Test_AllowAllAccessManager (t *testing.T) {
 
 // this test needs an external service running
 // TODO create mock service for testing
-func Dont_Test_RestAccessManager (t *testing.T) {
+func Dont_Test_RestAccessManager(t *testing.T) {
 	a := assert.New(t)
 	am := NewRestAccessManager("http://localhost:9000/follow/accessAllowed")
 	a.False(am.AccessAllowed(READ, "user", "/foo"))

--- a/server/accessmanager_test.go
+++ b/server/accessmanager_test.go
@@ -13,3 +13,15 @@ func Test_AllowAllAccessManager (t *testing.T) {
 	a.False(am.AccessAllowed(READ, "userid", "/path"))
 
 }
+
+// this test needs an external service running
+// TODO create mock service for testing
+func Dont_Test_RestAccessManager (t *testing.T) {
+	a := assert.New(t)
+	am := NewRestAccessManager("http://localhost:9000/follow/accessAllowed")
+	a.False(am.AccessAllowed(READ, "user", "/foo"))
+	a.True(am.AccessAllowed(READ, "foo", "/foo"))
+	a.True(am.AccessAllowed(WRITE, "foo", "/foo"))
+
+	a.False(am.AccessAllowed(READ, "user", "invalidpath"))
+}

--- a/server/accessmanager_test.go
+++ b/server/accessmanager_test.go
@@ -1,0 +1,15 @@
+package server
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_AllowAllAccessManager (t *testing.T) {
+	a := assert.New(t)
+	am := AccessManager(NewAllowAllAccessManager(true))
+	a.True(am.AccessAllowed(READ, "userid", "/path"))
+
+	am = AccessManager(NewAllowAllAccessManager(false))
+	a.False(am.AccessAllowed(READ, "userid", "/path"))
+
+}

--- a/server/interfaces.go
+++ b/server/interfaces.go
@@ -35,7 +35,7 @@ func NewRoute(path string, channel chan MsgAndRoute, applicationId string, userI
 }
 
 type PubSubSource interface {
-	Subscribe(r *Route) *Route
+	Subscribe(r *Route) (*Route, error)
 	Unsubscribe(r *Route)
 }
 
@@ -82,6 +82,10 @@ type SetKVStore interface {
 // Interface for modules, which need access to the message store
 type SetMessageStore interface {
 	SetMessageStore(messageStore store.MessageStore)
+}
+
+type SetAccessManager interface {
+	SetAccessManager(accessManager AccessManager)
 }
 
 type AccessType int

--- a/server/interfaces.go
+++ b/server/interfaces.go
@@ -83,3 +83,13 @@ type SetKVStore interface {
 type SetMessageStore interface {
 	SetMessageStore(messageStore store.MessageStore)
 }
+
+type AccessType int
+const (
+	READ AccessType = iota
+	WRITE
+)
+
+type AccessManager interface {
+	AccessAllowed(accessType AccessType, userId string, path guble.Path) bool
+}

--- a/server/mocks_server_gen_test.go
+++ b/server/mocks_server_gen_test.go
@@ -32,10 +32,10 @@ func (_m *MockPubSubSource) EXPECT() *_MockPubSubSourceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockPubSubSource) Subscribe(_param0 *Route) *Route {
+func (_m *MockPubSubSource) Subscribe(_param0 *Route) (*Route, error) {
 	ret := _m.ctrl.Call(_m, "Subscribe", _param0)
 	ret0, _ := ret[0].(*Route)
-	return ret0
+	return ret0, nil
 }
 
 func (_mr *_MockPubSubSourceRecorder) Subscribe(arg0 interface{}) *gomock.Call {

--- a/server/mocks_server_gen_test.go
+++ b/server/mocks_server_gen_test.go
@@ -35,7 +35,8 @@ func (_m *MockPubSubSource) EXPECT() *_MockPubSubSourceRecorder {
 func (_m *MockPubSubSource) Subscribe(_param0 *Route) (*Route, error) {
 	ret := _m.ctrl.Call(_m, "Subscribe", _param0)
 	ret0, _ := ret[0].(*Route)
-	return ret0, nil
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockPubSubSourceRecorder) Subscribe(arg0 interface{}) *gomock.Call {

--- a/server/receiver.go
+++ b/server/receiver.go
@@ -30,10 +30,11 @@ type Receiver struct {
 	shouldStop          bool
 	route               *Route
 	enableNotifications bool
+	userId				string
 }
 
 // Parses the info in the command
-func NewReceiverFromCmd(applicationId string, cmd *guble.Cmd, sendChannel chan []byte, messageSource PubSubSource, messageStore store.MessageStore) (*Receiver, error) {
+func NewReceiverFromCmd(applicationId string, cmd *guble.Cmd, sendChannel chan []byte, messageSource PubSubSource, messageStore store.MessageStore, userId string) (*Receiver, error) {
 	var err error
 	rec := &Receiver{
 		applicationId:       applicationId,
@@ -42,6 +43,7 @@ func NewReceiverFromCmd(applicationId string, cmd *guble.Cmd, sendChannel chan [
 		messageStore:        messageStore,
 		cancelChannel:       make(chan bool, 1),
 		enableNotifications: true,
+		userId:				 userId,
 	}
 	if len(cmd.Arg) == 0 || cmd.Arg[0] != '/' {
 		return nil, fmt.Errorf("command requires at least a path argument, but non given")
@@ -126,9 +128,13 @@ func (rec *Receiver) subscribeIfNoUnreadMessagesAvailable(maxMessageId uint64) e
 }
 
 func (rec *Receiver) subscribe() {
-	rec.route = NewRoute(string(rec.path), make(chan MsgAndRoute, 3), rec.applicationId, "TODO: remove userId from route")
-	rec.messageSouce.Subscribe(rec.route)
-	rec.sendOK(guble.SUCCESS_SUBSCRIBED_TO, string(rec.path))
+	rec.route = NewRoute(string(rec.path), make(chan MsgAndRoute, 3), rec.applicationId, rec.userId)
+	_, err := rec.messageSouce.Subscribe(rec.route)
+	if(err != nil) {
+		rec.sendError(guble.ERROR_SUBSCRIBED_TO, string(rec.path), err.Error())
+	} else {
+		rec.sendOK(guble.SUCCESS_SUBSCRIBED_TO, string(rec.path))
+	}
 }
 
 func (rec *Receiver) receiveFromSubscription() {
@@ -139,8 +145,6 @@ func (rec *Receiver) receiveFromSubscription() {
 				guble.Debug("messageSouce closed the channel returning from subscription", rec.applicationId)
 				return
 			}
-
-
 
 			if guble.DebugEnabled() {
 				guble.Debug("deliver message to applicationId=%v: %v", rec.applicationId, msgAndRoute.Message.MetadataLine())

--- a/server/receiver.go
+++ b/server/receiver.go
@@ -33,12 +33,12 @@ type Receiver struct {
 }
 
 // Parses the info in the command
-func NewReceiverFromCmd(applicationId string, cmd *guble.Cmd, sendChannel chan []byte, messageSouce PubSubSource, messageStore store.MessageStore) (*Receiver, error) {
+func NewReceiverFromCmd(applicationId string, cmd *guble.Cmd, sendChannel chan []byte, messageSource PubSubSource, messageStore store.MessageStore) (*Receiver, error) {
 	var err error
 	rec := &Receiver{
 		applicationId:       applicationId,
 		sendChannel:         sendChannel,
-		messageSouce:        messageSouce,
+		messageSouce:        messageSource,
 		messageStore:        messageStore,
 		cancelChannel:       make(chan bool, 1),
 		enableNotifications: true,
@@ -139,6 +139,9 @@ func (rec *Receiver) receiveFromSubscription() {
 				guble.Debug("messageSouce closed the channel returning from subscription", rec.applicationId)
 				return
 			}
+
+
+
 			if guble.DebugEnabled() {
 				guble.Debug("deliver message to applicationId=%v: %v", rec.applicationId, msgAndRoute.Message.MetadataLine())
 			}

--- a/server/receiver_test.go
+++ b/server/receiver_test.go
@@ -282,7 +282,7 @@ func aMockedReceiver(arg string) (*Receiver, chan []byte, *MockPubSubSource, *Mo
 		Name: guble.CMD_RECEIVE,
 		Arg:  arg,
 	}
-	rec, err := NewReceiverFromCmd("any-appId", cmd, sendChannel, pubSubSource, messageStore)
+	rec, err := NewReceiverFromCmd("any-appId", cmd, sendChannel, pubSubSource, messageStore, "userId")
 	return rec, sendChannel, pubSubSource, messageStore, err
 }
 

--- a/server/router.go
+++ b/server/router.go
@@ -25,14 +25,13 @@ type PubSubRouter struct {
 }
 
 func NewPubSubRouter() *PubSubRouter {
-	guble.Err("new router")
 	return &PubSubRouter{
 		routes:          make(map[guble.Path][]Route),
 		messageIn:       make(chan *guble.Message, 500),
 		subscribeChan:   make(chan SubscriptionRequest, 10),
 		unsubscribeChan: make(chan SubscriptionRequest, 10),
 		stop:            make(chan bool, 1),
-		accessManager:	NewAllowAllAccessManager(true),
+		accessManager:   NewAllowAllAccessManager(true),
 	}
 }
 
@@ -71,7 +70,7 @@ func (router *PubSubRouter) Stop() error {
 // Add a route to the subscribers.
 // If there is already a route with same Application Id and Path, it will be replaced.
 func (router *PubSubRouter) Subscribe(r *Route) *Route {
-	if(!router.accessManager.AccessAllowed(READ, r.UserId, r.Path)) {
+	if (!router.accessManager.AccessAllowed(READ, r.UserId, r.Path)) {
 		//TODO send error message to requesting user
 		return r;
 	}
@@ -121,11 +120,11 @@ func (router *PubSubRouter) unsubscribe(r *Route) {
 }
 
 func (router *PubSubRouter) HandleMessage(message *guble.Message) error {
-	if(!router.accessManager.AccessAllowed(WRITE, message.PublisherUserId, message.Path)) {
+	if (!router.accessManager.AccessAllowed(WRITE, message.PublisherUserId, message.Path)) {
 		return errors.New("User not allowed to post message to topic.")
 	}
 
-	if float32(len(router.messageIn))/float32(cap(router.messageIn)) > 0.9 {
+	if float32(len(router.messageIn)) / float32(cap(router.messageIn)) > 0.9 {
 		guble.Warn("router.messageIn channel very full: current=%v, max=%v\n", len(router.messageIn), cap(router.messageIn))
 		time.Sleep(time.Millisecond)
 	}
@@ -151,7 +150,7 @@ func (router *PubSubRouter) deliverMessage(route Route, message *guble.Message) 
 	defer guble.PanicLogger()
 	select {
 	case route.C <- MsgAndRoute{Message: message, Route: &route}:
-		// fine, we could send the message
+	// fine, we could send the message
 	default:
 		guble.Info("queue was full, closing delivery for route=%v to applicationId=%v", route.Path, route.ApplicationId)
 		close(route.C)
@@ -179,8 +178,8 @@ func matchesTopic(messagePath, routePath guble.Path) bool {
 	messagePathLen := len(string(messagePath))
 	routePathLen := len(string(routePath))
 	return strings.HasPrefix(string(messagePath), string(routePath)) &&
-		(messagePathLen == routePathLen ||
-			(messagePathLen > routePathLen && string(messagePath)[routePathLen] == '/'))
+	(messagePathLen == routePathLen ||
+	(messagePathLen > routePathLen && string(messagePath)[routePathLen] == '/'))
 }
 
 // remove a route from the supplied list,
@@ -195,5 +194,5 @@ func remove(slice []Route, route *Route) []Route {
 	if position == -1 {
 		return slice
 	}
-	return append(slice[:position], slice[position+1:]...)
+	return append(slice[:position], slice[position + 1:]...)
 }

--- a/server/router.go
+++ b/server/router.go
@@ -25,12 +25,14 @@ type PubSubRouter struct {
 }
 
 func NewPubSubRouter() *PubSubRouter {
+	guble.Err("new router")
 	return &PubSubRouter{
 		routes:          make(map[guble.Path][]Route),
 		messageIn:       make(chan *guble.Message, 500),
 		subscribeChan:   make(chan SubscriptionRequest, 10),
 		unsubscribeChan: make(chan SubscriptionRequest, 10),
 		stop:            make(chan bool, 1),
+		accessManager:	NewAllowAllAccessManager(true),
 	}
 }
 

--- a/server/router.go
+++ b/server/router.go
@@ -31,7 +31,6 @@ func NewPubSubRouter() *PubSubRouter {
 		subscribeChan:   make(chan SubscriptionRequest, 10),
 		unsubscribeChan: make(chan SubscriptionRequest, 10),
 		stop:            make(chan bool, 1),
-		accessManager:   NewAllowAllAccessManager(true),
 	}
 }
 
@@ -40,6 +39,10 @@ func (router *PubSubRouter) SetAccessManager(accessManager AccessManager) {
 }
 
 func (router *PubSubRouter) Go() *PubSubRouter {
+
+	if router.accessManager == nil {
+		panic("AccessManager not set. Cannot start.")
+	}
 	go func() {
 		for {
 			func() {

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -15,7 +15,9 @@ func TestAddAndRemoveRoutes(t *testing.T) {
 	a := assert.New(t)
 
 	// Given a Multiplexer
-	router := NewPubSubRouter().Go()
+	router := NewPubSubRouter()
+	router.SetAccessManager(NewAllowAllAccessManager(true))
+	router.Go()
 
 	// when i add two routes in the same path
 	channel := make(chan MsgAndRoute, chanSize)
@@ -51,8 +53,9 @@ func Test_SubscribeNotAllowed(t *testing.T ) {
 
 	tam := NewTestAccessManager();
 
-	router := NewPubSubRouter().Go()
+	router := NewPubSubRouter()
 	router.SetAccessManager(AccessManager(tam))
+	router.Go()
 
 	channel := make(chan MsgAndRoute, chanSize)
 	_, e := router.Subscribe(NewRoute("/blah", channel, "appid01", "user01"))
@@ -101,7 +104,10 @@ func TestReplacingOfRoutes(t *testing.T) {
 	a := assert.New(t)
 
 	// Given a router with a route
-	router := NewPubSubRouter().Go()
+	router := NewPubSubRouter()
+	router.SetAccessManager(NewAllowAllAccessManager(true))
+	router.Go()
+
 	router.Subscribe(NewRoute("/blah", nil, "appid01", "user01"))
 
 	// when: i add another route with the same Application Id and Same Path
@@ -130,7 +136,10 @@ func TestRoutingWithSubTopics(t *testing.T) {
 	a := assert.New(t)
 
 	// Given a Multiplexer with route
-	router := NewPubSubRouter().Go()
+	router := NewPubSubRouter()
+	router.SetAccessManager(NewAllowAllAccessManager(true))
+	router.Go()
+
 	channel := make(chan MsgAndRoute, chanSize)
 	r, _ := router.Subscribe(NewRoute("/blah", channel, "appid01", "user01"))
 
@@ -212,7 +221,9 @@ func TestRouteIsRemovedIfChannelIsFull(t *testing.T) {
 }
 
 func aRouterRoute() (*PubSubRouter, *Route) {
-	router := NewPubSubRouter().Go()
+	router := NewPubSubRouter()
+	router.SetAccessManager(NewAllowAllAccessManager(true))
+	router.Go()
 	route, _ :=router.Subscribe(NewRoute("/blah", make(chan MsgAndRoute, chanSize), "appid01", "user01"))
 	return router, route
 }

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -97,7 +97,7 @@ func aMockedService() (*Service, store.KVStore, store.MessageStore, *MockMessage
 	messageStore := store.NewDummyMessageStore()
 	messageSink := NewMockMessageSink(ctrl)
 	pubSubSource := NewMockPubSubSource(ctrl)
-	return NewService("localhost:0", kvStore, messageStore, messageSink, pubSubSource),
+	return NewService("localhost:0", kvStore, messageStore, messageSink, pubSubSource, NewAllowAllAccessManager(true)),
 		kvStore,
 		messageStore,
 		messageSink,

--- a/server/websocket_connector.go
+++ b/server/websocket_connector.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"strings"
 	"time"
-	"bytes"
 )
 
 var webSocketUpgrader = websocket.Upgrader{
@@ -101,7 +100,7 @@ func (srv *WSHandler) sendLoop() {
 		select {
 		case raw := <-srv.sendChannel:
 
-		   if(srv.checkAccess(raw)) {
+			if (srv.checkAccess(raw)) {
 				if guble.DebugEnabled() {
 					if len(raw) < 80 {
 						guble.Debug("send to client (userId=%v, applicationId=%v, totalSize=%v): %v", srv.userId, srv.applicationId, len(raw), string(raw))
@@ -132,15 +131,8 @@ func (srv *WSHandler) checkAccess(raw []byte) bool {
 }
 
 func getPathFromRawMessage(raw []byte) guble.Path {
-	path := &bytes.Buffer{}
-	for _, b := range raw {
-		if strings.EqualFold(string(b), ",") {
-			break
-		}
-		path.WriteByte(b);
-	}
-	return guble.Path(path.String())
-
+	i := strings.Index(string(raw), ",")
+	return guble.Path(raw[:i])
 }
 
 func (srv *WSHandler) receiveLoop() {


### PR DESCRIPTION
Ich habe einen AccessManager hinzugefügt, der den Lese- und Schreibzugriff (also subscribe, Nachrichten ausliefern, Nachrichten schreiben) prüft. Die doppelte Prüfung für den lesenden Zugriff (beim Subscribe, sowei beim verteilen der Nachricht) habe ich deshalb gemacht, falls ein User den Lese-Zugriff auf seinen Stream im Nachhinein wieder zurück zieht.

Es gibt ein paar Tests, die die entsprechenden Stellen abprüfen. Eine einfache Implementierung eines RestAccessManagers für meinen Service ist auch dabei, default ist aber der AllowAllAccessManager aktiv.

An ein paar Stellen musste ich Teile der API ändern um den Benutzernamen zu kriegen. Mit den Änderungen im websocket_connector bin ich noch nicht ganz zufrieden. Da musste ich mir den Path wieder aus dem byte[] der Nachricht raus holen.