### PR TITLE
Refactor/guble 25 unify services under the router

### DIFF
--- a/gubled/gubled.go
+++ b/gubled/gubled.go
@@ -43,7 +43,7 @@ var ValidateStoragePath = func(args Args) error {
 	return nil
 }
 
-var CreateKVStoreBackend = func(args Args) store.KVStore {
+var CreateKVStore = func(args Args) store.KVStore {
 	switch args.KVBackend {
 	case "memory":
 		return store.NewMemoryKVStore()
@@ -58,7 +58,7 @@ var CreateKVStoreBackend = func(args Args) store.KVStore {
 	}
 }
 
-var CreateMessageStoreBackend = func(args Args) store.MessageStore {
+var CreateMessageStore = func(args Args) store.MessageStore {
 	switch args.MSBackend {
 	case "none", "":
 		return store.NewDummyMessageStore()
@@ -119,16 +119,23 @@ func Main() {
 }
 
 func StartupService(args Args) *server.Service {
-	router := server.NewPubSubRouter()
-	router.SetAccessManager(server.NewAllowAllAccessManager(true))
+
+	accessManager := server.NewAllowAllAccessManager(true)
+	messageStore := CreateMessageStore(args)
+	kvStore := CreateKVStore(args)
+
+	router := server.NewPubSubRouter(accessManager, messageStore, kvStore)
+	messageEntry := server.NewMessageEntry(router)
+
 	router.Go()
 	service := server.NewService(
 		args.Listen,
-		CreateKVStoreBackend(args),
-		CreateMessageStoreBackend(args),
-		server.NewMessageEntry(router),
+		kvStore,
+		messageStore,
+		messageEntry,
 		router,
-		server.NewAllowAllAccessManager(true))
+		accessManager,
+	)
 
 	for _, module := range CreateModules(args) {
 		service.Register(module)

--- a/gubled/gubled_test.go
+++ b/gubled/gubled_test.go
@@ -25,12 +25,12 @@ func TestValidateStoragePath(t *testing.T) {
 func TestCreateKVStoreBackend(t *testing.T) {
 	a := assert.New(t)
 
-	memory := CreateKVStoreBackend(Args{KVBackend: "memory"})
+	memory := CreateKVStore(Args{KVBackend: "memory"})
 	a.Equal("*store.MemoryKVStore", reflect.TypeOf(memory).String())
 
 	dir, _ := ioutil.TempDir("", "guble_test")
 	defer os.RemoveAll(dir)
-	sqlite := CreateKVStoreBackend(Args{KVBackend: "file", StoragePath: dir})
+	sqlite := CreateKVStore(Args{KVBackend: "file", StoragePath: dir})
 	a.Equal("*store.SqliteKVStore", reflect.TypeOf(sqlite).String())
 }
 
@@ -168,7 +168,7 @@ func TestCreateStoreBackendPanicInvalidBackend(t *testing.T) {
 			p = recover()
 		}()
 
-		CreateKVStoreBackend(Args{KVBackend: "foo bar"})
+		CreateKVStore(Args{KVBackend: "foo bar"})
 	}()
 	a.NotNil(p)
 }

--- a/server/errors.go
+++ b/server/errors.go
@@ -1,0 +1,10 @@
+package server
+
+import (
+	"errors"
+)
+
+var (
+	// ErrServiceNotProvided is returned when the service required is not set.
+	ErrServiceNotProvided = errors.New("Service not provided.")
+)

--- a/server/router.go
+++ b/server/router.go
@@ -50,7 +50,6 @@ func (router *PubSubRouter) SetAccessManager(accessManager AccessManager) {
 }
 
 func (router *PubSubRouter) Go() *PubSubRouter {
-
 	if router.accessManager == nil {
 		panic("AccessManager not set. Cannot start.")
 	}
@@ -77,11 +76,13 @@ func (router *PubSubRouter) Go() *PubSubRouter {
 			}()
 		}
 	}()
+
 	return router
 }
 
+// Stop stops the router by closing the stop channel
 func (router *PubSubRouter) Stop() error {
-	router.stop <- true
+	close(router.stop)
 	return nil
 }
 

--- a/server/router.go
+++ b/server/router.go
@@ -3,6 +3,7 @@ package server
 import (
 	"errors"
 	"github.com/smancke/guble/guble"
+	"github.com/smancke/guble/store"
 	"runtime"
 	"strings"
 	"time"
@@ -20,16 +21,27 @@ type PubSubRouter struct {
 	subscribeChan   chan SubscriptionRequest
 	unsubscribeChan chan SubscriptionRequest
 	stop            chan bool
-	accessManager   AccessManager
+
+	// external services
+	accessManager AccessManager
+	messageStore  store.MessageStore
+	kvStore       store.KVStore
 }
 
-func NewPubSubRouter() *PubSubRouter {
+func NewPubSubRouter(
+	accessManager AccessManager,
+	messageStore store.MessageStore,
+	kvStore store.KVStore) *PubSubRouter {
 	return &PubSubRouter{
 		routes:          make(map[guble.Path][]Route),
 		messageIn:       make(chan *guble.Message, 500),
 		subscribeChan:   make(chan SubscriptionRequest, 10),
 		unsubscribeChan: make(chan SubscriptionRequest, 10),
 		stop:            make(chan bool, 1),
+
+		accessManager: accessManager,
+		messageStore:  messageStore,
+		kvStore:       kvStore,
 	}
 }
 
@@ -203,4 +215,28 @@ func remove(slice []Route, route *Route) []Route {
 		return slice
 	}
 	return append(slice[:position], slice[position+1:]...)
+}
+
+// AccessManager returns the `accessManager` provided for the router
+func (p *PubSubRouter) AccessManager() (AccessManager, error) {
+	if p.accessManager == nil {
+		return nil, ErrServiceNotProvided
+	}
+	return p.accessManager, nil
+}
+
+// MessageStore returns the `messageStore` provided for the router
+func (p *PubSubRouter) MessageStore() (store.MessageStore, error) {
+	if p.messageStore == nil {
+		return nil, ErrServiceNotProvided
+	}
+	return p.messageStore, nil
+}
+
+// KVStore returns the `kvStore` provided for the router
+func (p *PubSubRouter) KVStore() (store.KVStore, error) {
+	if p.kvStore == nil {
+		return nil, ErrServiceNotProvided
+	}
+	return p.kvStore, nil
 }

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -14,9 +14,10 @@ var chanSize = 10
 func TestAddAndRemoveRoutes(t *testing.T) {
 	a := assert.New(t)
 
+	accessManager := NewAllowAllAccessManager(true)
+
 	// Given a Multiplexer
-	router := NewPubSubRouter()
-	router.SetAccessManager(NewAllowAllAccessManager(true))
+	router := NewPubSubRouter(accessManager, nil, nil)
 	router.Go()
 
 	// when i add two routes in the same path
@@ -53,8 +54,7 @@ func Test_SubscribeNotAllowed(t *testing.T) {
 
 	tam := NewTestAccessManager()
 
-	router := NewPubSubRouter()
-	router.SetAccessManager(AccessManager(tam))
+	router := NewPubSubRouter(AccessManager(tam), nil, nil)
 	router.Go()
 
 	channel := make(chan MsgAndRoute, chanSize)
@@ -104,8 +104,7 @@ func TestReplacingOfRoutes(t *testing.T) {
 	a := assert.New(t)
 
 	// Given a router with a route
-	router := NewPubSubRouter()
-	router.SetAccessManager(NewAllowAllAccessManager(true))
+	router := NewPubSubRouter(NewAllowAllAccessManager(true), nil, nil)
 	router.Go()
 
 	router.Subscribe(NewRoute("/blah", nil, "appid01", "user01"))
@@ -136,8 +135,7 @@ func TestRoutingWithSubTopics(t *testing.T) {
 	a := assert.New(t)
 
 	// Given a Multiplexer with route
-	router := NewPubSubRouter()
-	router.SetAccessManager(NewAllowAllAccessManager(true))
+	router := NewPubSubRouter(NewAllowAllAccessManager(true), nil, nil)
 	router.Go()
 
 	channel := make(chan MsgAndRoute, chanSize)
@@ -221,8 +219,7 @@ func TestRouteIsRemovedIfChannelIsFull(t *testing.T) {
 }
 
 func aRouterRoute() (*PubSubRouter, *Route) {
-	router := NewPubSubRouter()
-	router.SetAccessManager(NewAllowAllAccessManager(true))
+	router := NewPubSubRouter(NewAllowAllAccessManager(true), nil, nil)
 	router.Go()
 	route, _ := router.Subscribe(NewRoute("/blah", make(chan MsgAndRoute, chanSize), "appid01", "user01"))
 	return router, route


### PR DESCRIPTION
This is the first step required to removing the DI part from the service and after that to create a `Router` interface.