### PR TITLE
Refactoring metrics to be disable-able by using build tag

### DIFF
--- a/gubled/config/config.go
+++ b/gubled/config/config.go
@@ -3,9 +3,6 @@ package config
 // Config package contains the public config vars required in guble
 
 import (
-	"os"
-	"strings"
-
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -50,10 +47,8 @@ var (
 	}
 
 	Metrics = struct {
-		Enabled  *bool
 		Endpoint *string
 	}{
-		Enabled: kingpin.Flag("metrics", "Enable collection of metrics").Envar("GUBLE_METRICS").Bool(),
 		Endpoint: kingpin.Flag("metrics-endpoint", `The metrics endpoint to be used by the HTTP server (disabled by default; a possible value for enabling it: "/_metrics" )`).
 			Default("").Envar("GUBLE_METRICS_ENDPOINT").String(),
 	}
@@ -91,6 +86,8 @@ var (
 		Default(log.ErrorLevel.String()).
 		Envar("GUBLE_LOG").
 		Enum(logLevels()...)
+
+	parsed = false
 )
 
 func logLevels() (levels []string) {
@@ -104,13 +101,9 @@ func logLevels() (levels []string) {
 // If there are missing or invalid arguments it will exit the application and display a
 // corresponding message
 func Parse() {
-	kingpin.Parse()
-}
-
-func init() {
-	// skip init if in test mode
-	if strings.HasSuffix(os.Args[0], ".test") {
+	if parsed {
 		return
 	}
-	Parse()
+	kingpin.Parse()
+	parsed = true
 }

--- a/gubled/config/config_test.go
+++ b/gubled/config/config_test.go
@@ -30,9 +30,6 @@ func TestParsingOfEnviromentVariables(t *testing.T) {
 	os.Setenv("GUBLE_HEALTH_ENDPOINT", "health_endpoint")
 	defer os.Unsetenv("GUBLE_HEALTH_ENDPOINT")
 
-	os.Setenv("GUBLE_METRICS", "true")
-	defer os.Unsetenv("GUBLE_METRICS")
-
 	os.Setenv("GUBLE_METRICS_ENDPOINT", "metrics_endpoint")
 	defer os.Unsetenv("GUBLE_METRICS_ENDPOINT")
 
@@ -91,7 +88,6 @@ func TestParsingArgs(t *testing.T) {
 		"--kvs", "kvs-backend",
 		"--ms", "ms-backend",
 		"--health-endpoint", "health_endpoint",
-		"--metrics",
 		"--metrics-endpoint", "metrics_endpoint",
 		"--gcm",
 		"--gcm-api-key", "gcm-api-key",
@@ -119,7 +115,6 @@ func assertArguments(a *assert.Assertions) {
 	a.Equal("ms-backend", *MS)
 	a.Equal("health_endpoint", *HealthEndpoint)
 
-	a.Equal(true, *Metrics.Enabled)
 	a.Equal("metrics_endpoint", *Metrics.Endpoint)
 
 	a.Equal(true, *GCM.Enabled)

--- a/metrics/base.go
+++ b/metrics/base.go
@@ -1,8 +1,6 @@
 package metrics
 
 import (
-	"github.com/smancke/guble/gubled/config"
-
 	log "github.com/Sirupsen/logrus"
 
 	"expvar"
@@ -11,25 +9,10 @@ import (
 	"net/http"
 )
 
-// IntVar is an interface for the operations defined on expvar.Int
+// IntVar is an interface for some of the operations defined on expvar.Int
 type IntVar interface {
 	Add(int64)
 	Set(int64)
-}
-
-type emptyInt struct{}
-
-// Dummy functions on EmptyInt
-func (v *emptyInt) Add(delta int64) {}
-
-func (v *emptyInt) Set(value int64) {}
-
-// NewInt returns an expvar.Int or a dummy emptyInt, depending on the Enabled flag
-func NewInt(name string) IntVar {
-	if *config.Metrics.Enabled {
-		return expvar.NewInt(name)
-	}
-	return &emptyInt{}
 }
 
 // HttpHandler is a HTTP handler writing the current metrics to the http.ResponseWriter
@@ -51,17 +34,15 @@ func writeMetrics(w io.Writer) {
 	fmt.Fprint(w, "\n}\n")
 }
 
+var logger = log.WithField("module", "metrics")
+
 // LogOnDebugLevel logs all the current metrics, if logging is on Debug level.
 func LogOnDebugLevel() {
-	if !*config.Metrics.Enabled {
-		log.Debug("metrics: not enabled")
-		return
-	}
-	if log.GetLevel() == log.DebugLevel {
+	if logger.Level == log.DebugLevel {
 		fields := log.Fields{}
 		expvar.Do(func(kv expvar.KeyValue) {
 			fields[kv.Key] = kv.Value
 		})
-		log.WithFields(fields).Debug("metrics: current values")
+		logger.WithFields(fields).Debug("current values of metrics")
 	}
 }

--- a/metrics/disabled.go
+++ b/metrics/disabled.go
@@ -1,0 +1,15 @@
+// +build disablemetrics
+
+package metrics
+
+type dummyInt struct{}
+
+// Dummy functions on dummyInt
+func (v *dummyInt) Add(delta int64) {}
+
+func (v *dummyInt) Set(value int64) {}
+
+// NewInt returns a dummyInt, depending on the build tag declared at the beginning of this file.
+func NewInt(name string) IntVar {
+	return &dummyInt{}
+}

--- a/metrics/doc.go
+++ b/metrics/doc.go
@@ -1,0 +1,3 @@
+// Metrics are enabled by default. If you want to disable metrics, build with:
+// go build -tags disablemetrics
+package metrics

--- a/metrics/enabled.go
+++ b/metrics/enabled.go
@@ -1,0 +1,12 @@
+// +build !disablemetrics
+
+package metrics
+
+import (
+	"expvar"
+)
+
+// NewInt returns an expvar Int, depending on the absence of build tag declared at the beginning of this file
+func NewInt(name string) IntVar {
+	return expvar.NewInt(name)
+}

--- a/metrics/enabled_test.go
+++ b/metrics/enabled_test.go
@@ -1,0 +1,13 @@
+package metrics
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"expvar"
+	"testing"
+)
+
+func TestNewInt(t *testing.T) {
+	_, ok := NewInt("a_name").(expvar.Var)
+	assert.True(t, ok)
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -39,16 +39,16 @@ func HttpHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func writeMetrics(w io.Writer) {
-	fmt.Fprintf(w, "{\n")
+	fmt.Fprint(w, "{\n")
 	first := true
 	expvar.Do(func(kv expvar.KeyValue) {
 		if !first {
-			fmt.Fprintf(w, ",\n")
+			fmt.Fprint(w, ",\n")
 		}
 		first = false
 		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
 	})
-	fmt.Fprintf(w, "\n}\n")
+	fmt.Fprint(w, "\n}\n")
 }
 
 // LogOnDebugLevel logs all the current metrics, if logging is on Debug level.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 )
 
+var logger = log.WithField("module", "metrics")
+
 // IntVar is an interface for some of the operations defined on expvar.Int
 type IntVar interface {
 	Add(int64)
@@ -34,11 +36,9 @@ func writeMetrics(w io.Writer) {
 	fmt.Fprint(w, "\n}\n")
 }
 
-var logger = log.WithField("module", "metrics")
-
 // LogOnDebugLevel logs all the current metrics, if logging is on Debug level.
 func LogOnDebugLevel() {
-	if logger.Level == log.DebugLevel {
+	if log.GetLevel() == log.DebugLevel {
 		fields := log.Fields{}
 		expvar.Do(func(kv expvar.KeyValue) {
 			fields[kv.Key] = kv.Value

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -30,7 +30,7 @@ func TestHttpHandler_MetricsNotEnabled(t *testing.T) {
 	log.Debugf("%s", b)
 }
 
-func TestLogOnDebugLevel_DebugAndDisabled(t *testing.T) {
+func TestLogOnDebugLevel_Debug(t *testing.T) {
 	a := assert.New(t)
 	bufferDebug := bytes.NewBuffer([]byte{})
 	log.SetOutput(bufferDebug)
@@ -40,6 +40,7 @@ func TestLogOnDebugLevel_DebugAndDisabled(t *testing.T) {
 	LogOnDebugLevel()
 
 	logContent, err := ioutil.ReadAll(bufferDebug)
+	log.Debugf("%s", logContent)
 	a.NoError(err)
 
 	a.Contains(string(logContent), "cmdline")

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -6,17 +6,11 @@ import (
 	log "github.com/Sirupsen/logrus"
 
 	"bytes"
-	"expvar"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
-
-func TestNewInt_Enabled(t *testing.T) {
-	_, ok := NewInt("a_name").(expvar.Var)
-	assert.True(t, ok)
-}
 
 func TestHttpHandler_MetricsNotEnabled(t *testing.T) {
 	a := assert.New(t)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"github.com/smancke/guble/gubled/config"
 	"github.com/stretchr/testify/assert"
 
 	log "github.com/Sirupsen/logrus"
@@ -14,16 +13,9 @@ import (
 	"testing"
 )
 
-func TestNewInt_Disabled(t *testing.T) {
-	_, ok := NewInt("a_name").(expvar.Var)
-	assert.False(t, ok)
-}
-
 func TestNewInt_Enabled(t *testing.T) {
-	*config.Metrics.Enabled = true
 	_, ok := NewInt("a_name").(expvar.Var)
 	assert.True(t, ok)
-	*config.Metrics.Enabled = false
 }
 
 func TestHttpHandler_MetricsNotEnabled(t *testing.T) {
@@ -38,21 +30,6 @@ func TestHttpHandler_MetricsNotEnabled(t *testing.T) {
 	log.Debugf("%s", b)
 }
 
-func TestLogOnDebugLevel_DebugAndEnabled(t *testing.T) {
-	a := assert.New(t)
-	bufferDebug := bytes.NewBuffer([]byte{})
-	log.SetOutput(bufferDebug)
-
-	log.SetLevel(log.DebugLevel)
-
-	LogOnDebugLevel()
-
-	logContent, err := ioutil.ReadAll(bufferDebug)
-	a.NoError(err)
-
-	a.Contains(string(logContent), "metrics: not enabled")
-}
-
 func TestLogOnDebugLevel_DebugAndDisabled(t *testing.T) {
 	a := assert.New(t)
 	bufferDebug := bytes.NewBuffer([]byte{})
@@ -60,9 +37,7 @@ func TestLogOnDebugLevel_DebugAndDisabled(t *testing.T) {
 
 	log.SetLevel(log.DebugLevel)
 
-	*config.Metrics.Enabled = true
 	LogOnDebugLevel()
-	*config.Metrics.Enabled = false
 
 	logContent, err := ioutil.ReadAll(bufferDebug)
 	a.NoError(err)
@@ -81,9 +56,7 @@ func TestLogOnDebugLevel_Info(t *testing.T) {
 	logContent, err := ioutil.ReadAll(bufferInfo)
 	a.NoError(err)
 
-	*config.Metrics.Enabled = true
 	LogOnDebugLevel()
-	*config.Metrics.Enabled = false
 
 	a.True(len(logContent) == 0)
 }

--- a/scripts/postgres.test.compose.yml
+++ b/scripts/postgres.test.compose.yml
@@ -1,6 +1,6 @@
 # docker compose file to run a test postgresql
 # start db with from root of project with following command:
-# `sudo docker-compose -f scripts/postgres.test.compose.yml up -d`
+# sudo docker-compose -f scripts/postgres.test.compose.yml up -d
 version: '2'
 services:
   postgres:


### PR DESCRIPTION
* refactoring metrics package to be independent of guble-config and enabled/disabled at build-time using a Go build tag: disablemetrics
* improved doc
* removed ugly code in config area