### PR TITLE
Always generating static executables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ after_success:
   - scripts/generate_coverage.sh
   - goveralls -coverprofile=full_cov.out -service=travis-ci
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
-      GOOS=linux go build -a --ldflags '-extldflags "-static"' . ;
-      GOOS=linux go build -a --ldflags '-extldflags "-static"' -o ./guble-cli/guble-cli ./guble-cli ;
+      GOOS=linux go build -a --ldflags '-linkmode external -extldflags "-static"' . ;
+      GOOS=linux go build -a --ldflags '-linkmode external -extldflags "-static"' -o ./guble-cli/guble-cli ./guble-cli ;
       docker build -t smancke/guble . ;
       docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" ;
       docker push smancke/guble ;


### PR DESCRIPTION
also guble-cli, not just guble
executables are used in docker image